### PR TITLE
Remove old opt-in for RequiresOptIn

### DIFF
--- a/clikt/build.gradle.kts
+++ b/clikt/build.gradle.kts
@@ -19,10 +19,6 @@ kotlin {
     macosArm64()
 
     sourceSets {
-        all {
-            languageSettings.optIn("kotlin.RequiresOptIn")
-        }
-
         val commonMain by getting {
             dependencies {
                 api(libs.mordant)


### PR DESCRIPTION
As of Kotlin 1.7 the opt-in feature is now stable and does not need an explicit declaration.

https://kotlinlang.org/docs/whatsnew17.html#stable-opt-in-requirements